### PR TITLE
Small change for count_ops().

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1068,49 +1068,49 @@ def count_ops(expr, visual=None):
         how = None
     else:
         how = True
-    if isinstance(expr, Expr):
 
+    if isinstance(expr, Expr):
         ops = []
         args = [expr]
-        MUL = C.Symbol('Mul')
+        NEG = C.Symbol('NEG')
+        DIV = C.Symbol('DIV')
         while args:
             a = args.pop()
             if a.is_Rational:
                 #-1/3 = -1*3**-1 -> Mul + Pow + Mul
                 if a is not S.One:
                     if a.p < 0:
-                        ops.append(MUL)
+                        ops.append(NEG)
                     if a.q != 1:
-                        ops.append(MUL)
+                        ops.append(DIV)
                     continue
             elif a.is_Mul:
                 if a.args[0] is S.NegativeOne:
-                    ops.append(MUL)
+                    ops.append(NEG)
                     a = a.as_two_terms()[1]
                 n, d = fraction(a)
+                if d is not S.One:
+                    ops.append(DIV)
                 if n.is_Integer:
-                    ops.append(MUL)
                     if n < 0:
-                        ops.append(MUL)
+                        ops.append(NEG)
                     a = d # won't be -Mul
                 elif d is not S.One:
                     if not d.is_Integer:
                         args.append(d)
-                    ops.append(MUL)
                     args.append(n)
                     continue # could be -Mul
             if a.is_Pow and a.exp is S.NegativeOne:
-                ops.append(MUL)
+                ops.append(DIV)
                 a = a.base # won't be -Mul
-            if (
-            a.is_Add or
-            a.is_Mul or
-            a.is_Pow or
-            a.is_Function or
-            isinstance(a, Derivative) or
-            isinstance(a, C.Integral)):
+            if (a.is_Add or
+                a.is_Mul or
+                a.is_Pow or
+                a.is_Function or
+                isinstance(a, Derivative) or
+                isinstance(a, C.Integral)):
 
-                o = C.Symbol(a.func.__name__)
+                o = C.Symbol(a.func.__name__.upper())
                 # count the args
                 if (a.is_Add or
                     a.is_Mul or


### PR DESCRIPTION
Hi Chris,

I played a bit with count_ops() today, and I think everything is fine now with visual=False.
Concerning visual=True, I thought about adding some 'virtual' operations, like DIV and NEG:

```
>>> count_ops(1/x, visual=True)
DIV
>>> count_ops(-x, visual=True)
NEG
```

What do you think of this ?

I also prefer uppercase, since returning Add or sin may be confusing:

```
In [6]: count_ops(sin(x),visual=True)
Out[6]: sin

In [7]: count_ops(sin(x),visual=True) is sin
Out[7]: False
```
